### PR TITLE
Rewrite context variablenames

### DIFF
--- a/src/Components/AddMealForm.js
+++ b/src/Components/AddMealForm.js
@@ -77,14 +77,14 @@ export default function AddMealForm() {
         onClick={(e) => {
           e.preventDefault();
           const input = formValues;
-          const newItem = ItemCtrl.addItem(input.name, input.calories);
+          const newMeal = ItemCtrl.addMeal(input.name, input.calories);
 
           //now to store item in localStorage
           if (input.name !== "" && input.calories !== "") {
-            StorageCtrl.storeItem(newItem);
+            StorageCtrl.storeMeal(newMeal);
           }
 
-          setMyThings(StorageCtrl.getItemsFromStorage());
+          setMyThings(StorageCtrl.getMealsFromStorage());
           setFormValues({ name: "", calories: 0 });
         }}
       >

--- a/src/Components/AddMealForm.js
+++ b/src/Components/AddMealForm.js
@@ -13,8 +13,8 @@ import StorageCtrl from "../CrudFunctions/StorageCtrl";
 import ItemCtrl from "../CrudFunctions/ItemCtrl";
 
 export default function AddMealForm() {
-  //setMyThings lets user update meal list in context
-  const { setMyThings } = useContext(ThingsContext);
+  //setmealsListGlobalState lets user update meal list in context
+  const { setmealsListGlobalState } = useContext(ThingsContext);
 
   const [formValues, setFormValues] = useState({ name: "", calories: 0 });
 
@@ -84,7 +84,7 @@ export default function AddMealForm() {
             StorageCtrl.storeMeal(newMeal);
           }
 
-          setMyThings(StorageCtrl.getMealsFromStorage());
+          setmealsListGlobalState(StorageCtrl.getMealsFromStorage());
           setFormValues({ name: "", calories: 0 });
         }}
       >

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -33,7 +33,7 @@ export default Header;
 
 const clearAllItemsClick = (setMyThings) => {
   //delete all items
-  ItemCtrl.clearAllItems();
-  StorageCtrl.clearItemsFromStorage();
+  ItemCtrl.clearAllMeals();
+  StorageCtrl.clearMealsFromStorage();
   setMyThings([]);
 };

--- a/src/Components/Header.js
+++ b/src/Components/Header.js
@@ -8,8 +8,8 @@ import { useContext } from "react";
 import ThingsContext from "../Context/MyContext";
 
 const Header = () => {
-  //setMyThings lets user update context (meals list)
-  const { setMyThings } = useContext(ThingsContext);
+  //setmealsListGlobalState lets user update context (meals list)
+  const { setmealsListGlobalState } = useContext(ThingsContext);
 
   return (
     <AppBar id="header-styling" data-testid="appBar">
@@ -20,7 +20,7 @@ const Header = () => {
         data-testid="clear-all-btn"
         onClick={() => {
           //delete all items
-          clearAllItemsClick(setMyThings);
+          clearAllItemsClick(setmealsListGlobalState);
         }}
       >
         Clear All
@@ -31,9 +31,9 @@ const Header = () => {
 
 export default Header;
 
-const clearAllItemsClick = (setMyThings) => {
+const clearAllItemsClick = (setmealsListGlobalState) => {
   //delete all items
   ItemCtrl.clearAllMeals();
   StorageCtrl.clearMealsFromStorage();
-  setMyThings([]);
+  setmealsListGlobalState([]);
 };

--- a/src/Components/MealDisplayContainer.js
+++ b/src/Components/MealDisplayContainer.js
@@ -5,12 +5,12 @@ import ThingsContext from "../Context/MyContext";
 import { useContext } from "react";
 
 const MealDisplayContainer = () => {
-  // myThings is the array of all meals, taken from context
-  const { myThings } = useContext(ThingsContext);
+  // mealsListGlobalState is the array of all meals, taken from context
+  const { mealsListGlobalState } = useContext(ThingsContext);
 
   return (
     <ul className="meal-display-container">
-      {myThings.map((item) => {
+      {mealsListGlobalState.map((item) => {
         const { name, calories, id } = item;
         return <SingleMeal name={name} calories={calories} id={id} key={id} />;
       })}

--- a/src/Components/SingleMeal.js
+++ b/src/Components/SingleMeal.js
@@ -10,8 +10,8 @@ import { Button, TextField } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
 
 const SingleMeal = (props) => {
-  //setMyThings updates context with the edited meal. Used for editing.
-  const { setMyThings } = useContext(ThingsContext);
+  //setmealsListGlobalState updates context with the edited meal. Used for editing.
+  const { setmealsListGlobalState } = useContext(ThingsContext);
   const { name, calories, id } = props;
   //isEditMode is toggled when user clicks edit button
   const [isEditMode, setIsEditMode] = useState(false);
@@ -47,7 +47,7 @@ const SingleMeal = (props) => {
             {/* Delete selected item */}
             <Button
               onClick={() => {
-                deleteSingleMealClick(id, setMyThings);
+                deleteSingleMealClick(id, setmealsListGlobalState);
               }}
             >
               <DeleteIcon />
@@ -60,7 +60,7 @@ const SingleMeal = (props) => {
         editForm(
           formValues,
           setFormValues,
-          setMyThings,
+          setmealsListGlobalState,
           calories,
           setIsEditMode
         )}
@@ -71,23 +71,23 @@ const SingleMeal = (props) => {
 export default SingleMeal;
 
 //edit current item
-const updateCurrentMeal = (newMealObject, setMyThings) => {
+const updateCurrentMeal = (newMealObject, setmealsListGlobalState) => {
   StorageCtrl.updateMealStorage(newMealObject);
-  setMyThings(StorageCtrl.getMealsFromStorage());
+  setmealsListGlobalState(StorageCtrl.getMealsFromStorage());
 };
 
 //Delete selected item
-const deleteSingleMealClick = (id, setMyThings) => {
+const deleteSingleMealClick = (id, setmealsListGlobalState) => {
   StorageCtrl.deleteMealFromStorage(id);
   const newContext = StorageCtrl.getMealsFromStorage();
-  setMyThings(newContext);
+  setmealsListGlobalState(newContext);
 };
 
 //this is the edit form, I put it down here to keep things more readable. Only shows up after clicking edit button
 const editForm = (
   formValues,
   setFormValues,
-  setMyThings,
+  setmealsListGlobalState,
   calories,
   setIsEditMode
 ) => {
@@ -97,7 +97,7 @@ const editForm = (
       data-testid="single-meal-edit-form"
       onSubmit={(e) => {
         e.preventDefault();
-        updateCurrentMeal(formValues, setMyThings);
+        updateCurrentMeal(formValues, setmealsListGlobalState);
         setIsEditMode(false);
       }}
     >

--- a/src/Components/SingleMeal.js
+++ b/src/Components/SingleMeal.js
@@ -47,7 +47,7 @@ const SingleMeal = (props) => {
             {/* Delete selected item */}
             <Button
               onClick={() => {
-                deleteSingleItemClick(id, setMyThings);
+                deleteSingleMealClick(id, setMyThings);
               }}
             >
               <DeleteIcon />
@@ -72,14 +72,14 @@ export default SingleMeal;
 
 //edit current item
 const updateCurrentMeal = (newMealObject, setMyThings) => {
-  StorageCtrl.updateItemStorage(newMealObject);
-  setMyThings(StorageCtrl.getItemsFromStorage());
+  StorageCtrl.updateMealStorage(newMealObject);
+  setMyThings(StorageCtrl.getMealsFromStorage());
 };
 
 //Delete selected item
-const deleteSingleItemClick = (id, setMyThings) => {
-  StorageCtrl.deleteItemFromStorage(id);
-  const newContext = StorageCtrl.getItemsFromStorage();
+const deleteSingleMealClick = (id, setMyThings) => {
+  StorageCtrl.deleteMealFromStorage(id);
+  const newContext = StorageCtrl.getMealsFromStorage();
   setMyThings(newContext);
 };
 

--- a/src/Components/TotalCalories.js
+++ b/src/Components/TotalCalories.js
@@ -10,7 +10,7 @@ const TotalCalories = () => {
 
   //For some reason, the total calories finder function from ItemCtrl.js didn't work right. Either I was using it wrong or it was buggy.
   //So I wrote my own here.
-  const currentData = StorageCtrl.getItemsFromStorage();
+  const currentData = StorageCtrl.getMealsFromStorage();
   let totalCalories = 0;
 
   currentData.forEach((item) => {

--- a/src/Components/TotalCalories.js
+++ b/src/Components/TotalCalories.js
@@ -19,7 +19,7 @@ const TotalCalories = () => {
 
   return (
     <h3 data-testid="total-calories-h3" className="total-calories-h3">
-      Total Calories: {totalCalories}
+      Total Calories: {Number(totalCalories)}
     </h3>
   );
 };

--- a/src/Context/MyContext.js
+++ b/src/Context/MyContext.js
@@ -13,10 +13,12 @@ export const ThingsProvider = ({ children }) => {
   // "Things" is the list of meals
   const things = StorageCtrl.getMealsFromStorage();
   //allows components to edit and view list of meals
-  const [myThings, setMyThings] = useState(things);
+  const [mealsListGlobalState, setmealsListGlobalState] = useState(things);
 
   return (
-    <ThingsContext.Provider value={{ myThings, setMyThings }}>
+    <ThingsContext.Provider
+      value={{ mealsListGlobalState, setmealsListGlobalState }}
+    >
       {children}
     </ThingsContext.Provider>
   );

--- a/src/Context/MyContext.js
+++ b/src/Context/MyContext.js
@@ -11,8 +11,7 @@ export default ThingsContext;
 
 export const ThingsProvider = ({ children }) => {
   // "Things" is the list of meals
-  const things = StorageCtrl.getItemsFromStorage();
-
+  const things = StorageCtrl.getMealsFromStorage();
   //allows components to edit and view list of meals
   const [myThings, setMyThings] = useState(things);
 

--- a/src/CrudFunctions/ItemCtrl.js
+++ b/src/CrudFunctions/ItemCtrl.js
@@ -1,8 +1,8 @@
 import StorageCtrl from "./StorageCtrl";
 
-const ItemCtrl = (function () {
-  // Item Constructor
-  const Item = function (id, name, calories) {
+const mealCtrl = (function () {
+  // meal Constructor
+  const meal = function (id, name, calories) {
     this.id = id;
     this.name = name;
     this.calories = calories;
@@ -10,21 +10,21 @@ const ItemCtrl = (function () {
 
   // Data Structure / State
   const data = {
-    items: StorageCtrl.getItemsFromStorage(),
-    currentItem: null,
+    meals: StorageCtrl.getMealsFromStorage(),
+    currentMeal: null,
     totalCalories: 0,
   };
 
   // Public methods
   return {
-    getItems: function () {
-      return data.items;
+    getMeals: function () {
+      return data.meals;
     },
-    addItem: function (name, calories) {
+    addMeal: function (name, calories) {
       let ID;
       // Create ID
-      if (data.items.length > 0) {
-        ID = data.items[data.items.length - 1].id + 1;
+      if (data.meals.length > 0) {
+        ID = data.meals[data.meals.length - 1].id + 1;
       } else {
         ID = 0;
       }
@@ -32,67 +32,67 @@ const ItemCtrl = (function () {
       // Calories to number
       calories = parseInt(calories);
 
-      // Create new item
+      // Create new meal
       //added a Let before this line (AD)
-      let newItem = new Item(ID, name, calories);
+      let newMeal = new meal(ID, name, calories);
 
-      // Add to items array
-      data.items.push(newItem);
+      // Add to meals array
+      data.meals.push(newMeal);
 
-      return newItem;
+      return newMeal;
     },
-    getItemById: function (id) {
+    getMealById: function (id) {
       let found = null;
-      // Loop through items
-      data.items.forEach(function (item) {
-        if (item.id === id) {
-          found = item;
+      // Loop through meals
+      data.meals.forEach(function (meal) {
+        if (meal.id === id) {
+          found = meal;
         }
       });
       return found;
     },
-    updateItem: function (name, calories, id) {
+    updateMeal: function (name, calories, id) {
       // Calories to number
       calories = parseInt(calories);
 
       let found = null;
 
-      data.items.forEach(function (item) {
-        if (item.id === id) {
-          item.name = name;
-          item.calories = calories;
-          found = item;
+      data.meals.forEach(function (meal) {
+        if (meal.id === id) {
+          meal.name = name;
+          meal.calories = calories;
+          found = meal;
         }
       });
       return found;
     },
-    deleteItem: function (id) {
+    deleteMeal: function (id) {
       // Get ids
-      const ids = data.items.map(function (item) {
-        return item.id;
+      const ids = data.meals.map(function (meal) {
+        return meal.id;
       });
 
       // Get index
       const index = ids.indexOf(id);
 
-      // Remove item
-      data.items.splice(index, 1);
+      // Remove meal
+      data.meals.splice(index, 1);
     },
-    clearAllItems: function () {
-      data.items = [];
+    clearAllMeals: function () {
+      data.meals = [];
     },
-    setCurrentItem: function (item) {
-      data.currentItem = item;
+    setCurrentMeal: function (meal) {
+      data.currentmeal = meal;
     },
-    getCurrentItem: function () {
-      return data.currentItem;
+    getCurrentMeal: function () {
+      return data.currentMeal;
     },
     getTotalCalories: function () {
       let total = 0;
 
-      // Loop through items and add cals
-      data.items.forEach(function (item) {
-        total += item.calories;
+      // Loop through meals and add cals
+      data.meals.forEach(function (meal) {
+        total += meal.calories;
       });
 
       // Set total cal in data structure
@@ -107,4 +107,4 @@ const ItemCtrl = (function () {
   };
 })();
 
-export default ItemCtrl;
+export default mealCtrl;

--- a/src/CrudFunctions/StorageCtrl.js
+++ b/src/CrudFunctions/StorageCtrl.js
@@ -2,66 +2,66 @@
 const StorageCtrl = (function () {
   // Public methods
   return {
-    storeItem: function (item) {
-      let items;
+    storeMeal: function (meal) {
+      let meals;
 
-      // Check if any items in localStorage
-      if (localStorage.getItem("items") === null) {
-        // no items in localStorage
-        items = [];
-        // Push new item
-        items.push(item);
+      // Check if any meals in localStorage
+      if (localStorage.getItem("meals") === null) {
+        // no meals in localStorage
+        meals = [];
+        // Push new meal
+        meals.push(meal);
         // Set localStorage
-        localStorage.setItem("items", JSON.stringify(items));
+        localStorage.setItem("meals", JSON.stringify(meals));
       } else {
         // Get what is already in localStorage
-        items = JSON.parse(localStorage.getItem("items"));
-        // Push new item
-        items.push(item);
+        meals = JSON.parse(localStorage.getItem("meals"));
+        // Push new meal
+        meals.push(meal);
         // Reset localStorage
-        localStorage.setItem("items", JSON.stringify(items));
+        localStorage.setItem("meals", JSON.stringify(meals));
       }
     },
 
-    getItemsFromStorage: function () {
-      let items;
+    getMealsFromStorage: function () {
+      let meals;
 
-      if (localStorage.getItem("items") === null) {
+      if (localStorage.getItem("meals") === null) {
         // Nothing in localStorage
-        items = [];
+        meals = [];
       } else {
-        items = JSON.parse(localStorage.getItem("items"));
+        meals = JSON.parse(localStorage.getItem("meals"));
       }
 
-      return items;
+      return meals;
     },
 
-    updateItemStorage: function (updatedItem) {
-      let items = JSON.parse(localStorage.getItem("items"));
+    updateMealStorage: function (updatedMeal) {
+      let meals = JSON.parse(localStorage.getItem("meals"));
 
-      items.forEach(function (item, index) {
-        if (updatedItem.id === item.id) {
-          items.splice(index, 1, updatedItem);
+      meals.forEach(function (meal, index) {
+        if (updatedMeal.id === meal.id) {
+          meals.splice(index, 1, updatedMeal);
         }
       });
 
-      localStorage.setItem("items", JSON.stringify(items));
+      localStorage.setItem("meals", JSON.stringify(meals));
     },
 
-    deleteItemFromStorage: function (id) {
-      let items = JSON.parse(localStorage.getItem("items"));
+    deleteMealFromStorage: function (id) {
+      let meals = JSON.parse(localStorage.getMeal("meals"));
 
-      items.forEach(function (item, index) {
-        if (id === item.id) {
-          items.splice(index, 1);
+      meals.forEach(function (meal, index) {
+        if (id === meal.id) {
+          meals.splice(index, 1);
         }
       });
 
-      localStorage.setItem("items", JSON.stringify(items));
+      localStorage.setItem("meals", JSON.stringify(meals));
     },
 
-    clearItemsFromStorage: function () {
-      localStorage.removeItem("items");
+    clearMealsFromStorage: function () {
+      localStorage.removeItem("meals");
     },
   };
 })();


### PR DESCRIPTION
GOAL (Accomplished):
Major rewrite of state and ItemCtrl/StorageCtrl variable names

Actions:
Changed all instances of "item" in variable names to "meal"
Changed {myThings, setMyThings} in context to {mealsListGlobalState, setmealsListGlobalState}

I did this because I felt that "meals" was much more descriptive than "items" for a list of meals.