### PR TITLE
Bug/singlemeal delete button doesnt work

### DIFF
--- a/src/CrudFunctions/StorageCtrl.js
+++ b/src/CrudFunctions/StorageCtrl.js
@@ -49,7 +49,7 @@ const StorageCtrl = (function () {
     },
 
     deleteMealFromStorage: function (id) {
-      let meals = JSON.parse(localStorage.getMeal("meals"));
+      let meals = JSON.parse(localStorage.getItem("meals"));
 
       meals.forEach(function (meal, index) {
         if (id === meal.id) {


### PR DESCRIPTION
ISSUE:
Single meal delete button doesn't do anything

GOAL(ACCOMPLISHED):
Debug and fix it so delete icon works (Accomplished. Yay!)

ACTIONS:
+Discovered issue is small typo in StorageCtrl.deleteMealFromStorage
(the function said localStorage.setMeal instead of localStorage.setItem)
+Fixed Typo

All tests currently pass. Ready for PR