### PR TITLE
Bug/fix addmealform styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -50,6 +50,7 @@ form {
   margin-top: 90px;
   display: flex;
   flex-direction: column;
+  box-shadow: none;
 }
 
 .add-meal-form-h2 {


### PR DESCRIPTION
Very simple PR: There was an extraneous line between the text fields in AddMealForm. I got rid of the line by removing box shadow from #add-meal-form.

All tests currently pass.