### PR TITLE
Simple fix: Edit meal name didn't have a placeholder, I put in a plac…

### DIFF
--- a/src/Components/SingleMeal.js
+++ b/src/Components/SingleMeal.js
@@ -56,12 +56,14 @@ const SingleMeal = (props) => {
         </>
       )}
       {/* When edit mode IS selected, this edit form displays */}
+
       {isEditMode &&
         generateSingleMealEditForm(
           formValues,
           setFormValues,
           setmealsListGlobalState,
           calories,
+          name,
           setIsEditMode
         )}
     </li>
@@ -89,6 +91,7 @@ const generateSingleMealEditForm = (
   setFormValues,
   setmealsListGlobalState,
   calories,
+  name,
   setIsEditMode
 ) => {
   return (
@@ -103,7 +106,7 @@ const generateSingleMealEditForm = (
     >
       <TextField
         data-testid="edit-meal-name-input"
-        placeholder={formValues.name}
+        placeholder={name}
         type="text"
         name="meal-name"
         value={formValues.name}


### PR DESCRIPTION
OVERVIEW:
Very simple pr:
-Edit meal form didn't have a placeholder in the name field, so I instated one.  The placeholder is the name of the meal being edited.